### PR TITLE
Fix memory leak in Lazy-k implementation

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,7 +5,7 @@ name: lazyk
 
 on:
   push:
-    branches: [ "main"]
+  pull_request:
 
 permissions:
   contents: read

--- a/src/lazyk_pybind.cpp
+++ b/src/lazyk_pybind.cpp
@@ -7,8 +7,8 @@
 namespace py = pybind11;  
 
 PYBIND11_MODULE(lazyk, m) {  
-    py::class_<Lazyk>(m, "lazyk")  
-        .def(py::init<vector<vector<double>>, bool>(), py::arg("probs"), py::arg("cache_assignments") = true)
+    py::class_<Lazyk>(m, "lazyk")
+        .def(py::init<const vector<vector<double>> &, bool>(), py::arg("probs"), py::arg("cache_assignments") = true)
         .def("__iter__", [](Lazyk &self) { return self; })  
         .def("__next__", [](Lazyk &self) {  
             if (self.end()) {  


### PR DESCRIPTION
## Summary
- avoid redundant state construction
- remove unused optional include
- return vectors by value from `nextBest`
- update logic to handle empty vectors rather than null pointers
- optimize interfaces to take const references

## Testing
- `poetry install`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406096b1d483268b5a1f778c00ccaa